### PR TITLE
Configure docs build for GitHub Pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,4 @@ These instructions apply to the entire repository.
 - Place Svelte components under `frontend/src/components/` and pages under `frontend/src/pages/`.
 - Backend code should remain under `backend/` and use Express with CommonJS modules.
 - Ensure tests remain passing after your changes.
+- Save understandable instructions for future agents in this AGENTS.md format.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,6 @@
   <body>
     <div id="root"></div>
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script type="module" src="/cryptonewton/frontend/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [svelte()],
   build: {
     outDir: '../docs'

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,7 +3,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: './',
+  base: '/docs/',
   plugins: [svelte()],
   build: {
     outDir: '../docs'

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [svelte()],
+  build: {
+    outDir: '../docs'
+  }
 })

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node backend/index.js",
     "bot": "node bot/bot.js",
-    "test": "jest"
+    "test": "jest",
+    "build": "npm --prefix frontend run build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- build frontend into docs for GitHub Pages
- fix module path in frontend index

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68662c4629808322b96ccddefab353a8