### PR TITLE
Add loading overlay with spinner

### DIFF
--- a/frontend/src/pages/Buy.svelte
+++ b/frontend/src/pages/Buy.svelte
@@ -10,6 +10,7 @@
     const userId = tg.initDataUnsafe?.user?.id;
     if (!userId || amount < 1) return;
     loading = true;
+    await new Promise(r => setTimeout(r, 5000));
     const res = await purchase(userId, amount);
     loading = false;
     if (res.ok) navigate('/success');
@@ -18,9 +19,41 @@
 </script>
 
   <div class="container">
-    {#if loading}
-      <p>Загрузка...</p>
-    {/if}
     <AmountPicker onSelect={val => amount = val} />
     <button class="btn" on:click={confirm} disabled={loading}>Купить</button>
   </div>
+
+  {#if loading}
+    <div class="overlay">
+      <div class="spinner"></div>
+      <p>Загрузка...</p>
+    </div>
+  {/if}
+
+  <style>
+  .overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: var(--tg-bg-color, rgba(255,255,255,0.9));
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+  .spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px solid var(--tg-hint-color, #ccc);
+    border-top-color: var(--tg-button-color, #0077ff);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-bottom: 10px;
+  }
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+  </style>

--- a/frontend/src/pages/Success.svelte
+++ b/frontend/src/pages/Success.svelte
@@ -3,6 +3,27 @@
 </script>
 
 <div class="container">
-  <p>🎉 Успешно</p>
+  <div class="check">✓</div>
+  <p>Готово</p>
   <button class="btn" on:click={() => navigate('/')}>На главную</button>
 </div>
+
+<style>
+.check {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: 4px solid var(--tg-button-color, #0077ff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 20px auto;
+  font-size: 48px;
+  color: var(--tg-button-color, #0077ff);
+  animation: pop 0.5s ease;
+}
+@keyframes pop {
+  0% { transform: scale(0); }
+  100% { transform: scale(1); }
+}
+</style>


### PR DESCRIPTION
## Summary
- show spinner overlay during purchase
- simulate 5‑second delay before navigating to done screen
- animate success page with a checkmark

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866bbc60c78832289c80859c252e908