### PR TITLE
Add animated UI

### DIFF
--- a/frontend/src/components/HistoryCard.svelte
+++ b/frontend/src/components/HistoryCard.svelte
@@ -1,0 +1,42 @@
+<script>
+  export let record;
+  let open = false;
+  function toggle() {
+    open = !open;
+  }
+</script>
+
+<div class="card" on:click={toggle}>
+  <div class="summary">
+    <span>{new Date(record.time).toLocaleDateString()}</span>
+    <span>{record.amount} ⭐</span>
+  </div>
+  {#if open}
+    <div class="details">
+      <p>${record.fiat.toFixed(2)}</p>
+      <p>{new Date(record.time).toLocaleString()}</p>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .card {
+    background: #fff;
+    color: #000;
+    border-radius: 8px;
+    padding: 12px;
+    margin-bottom: 10px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    cursor: pointer;
+  }
+  .summary {
+    display: flex;
+    justify-content: space-between;
+    font-weight: bold;
+  }
+  .details {
+    margin-top: 8px;
+    font-size: 14px;
+    color: #555;
+  }
+</style>

--- a/frontend/src/components/RippleButton.svelte
+++ b/frontend/src/components/RippleButton.svelte
@@ -1,0 +1,64 @@
+<script>
+  export let onClick = () => {};
+  export let disabled = false;
+  let ripples = [];
+
+  function createRipple(event) {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const size = Math.max(rect.width, rect.height);
+    const x = event.clientX - rect.left - size / 2;
+    const y = event.clientY - rect.top - size / 2;
+    const ripple = { x, y, size, key: Date.now() };
+    ripples = [...ripples, ripple];
+    setTimeout(() => {
+      ripples = ripples.filter(r => r.key !== ripple.key);
+    }, 600);
+    onClick(event);
+  }
+</script>
+
+<button class="ripple-btn" on:click={createRipple} disabled={disabled}>
+  <slot></slot>
+  <span class="ripple-box">
+    {#each ripples as r (r.key)}
+      <span
+        class="ripple"
+        style="width:{r.size}px;height:{r.size}px;top:{r.y}px;left:{r.x}px;"
+      />
+    {/each}
+  </span>
+</button>
+
+<style>
+  .ripple-btn {
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    width: 100%;
+    background: #fff;
+    color: #000;
+    border-radius: 8px;
+    font-size: 16px;
+  }
+  .ripple-box {
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+  }
+  .ripple {
+    position: absolute;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.3);
+    transform: scale(0);
+    animation: ripple 0.6s linear;
+  }
+  @keyframes ripple {
+    to {
+      transform: scale(4);
+      opacity: 0;
+    }
+  }
+</style>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -120,3 +120,9 @@ button:hover {
     transform: scale(1.2);
   }
 }
+
+.fancy-text {
+  background: linear-gradient(90deg,#ff8a00,#e52e71);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}

--- a/frontend/src/pages/Buy.svelte
+++ b/frontend/src/pages/Buy.svelte
@@ -3,6 +3,7 @@
   import LoadingOverlay from "../components/LoadingOverlay.svelte";
   import { purchase } from "../api.js";
   import { navigate } from "../router.js";
+  import RippleButton from "../components/RippleButton.svelte";
   import { tg } from "../tg.js";
   const PRICE_USD = 0.05;
   let amount = 0;
@@ -28,10 +29,10 @@
 </script>
 
 <div class="container">
-  <h2><button class="btn" on:click={() => navigate("/")}>🢀</button> Сколько желаете?</h2>
+  <h2><RippleButton onClick={() => navigate("/")}>🢀</RippleButton> Сколько желаете?</h2>
   <AmountPicker onSelect={(val) => (amount = val)} />
 
-  <button style="margin-top: 8px;" class="btn" on:click={confirm} disabled={loading}>Купить</button>
+  <RippleButton onClick={confirm} disabled={loading} style="margin-top: 8px;">Купить</RippleButton>
 </div>
 
 {#if loading}

--- a/frontend/src/pages/Gift.svelte
+++ b/frontend/src/pages/Gift.svelte
@@ -4,6 +4,7 @@
   import { navigate } from '../router.js';
   import { tg } from '../tg.js';
   import { gift } from '../api.js';
+  import RippleButton from '../components/RippleButton.svelte';
 
   let amount = 0;
   const params = new URLSearchParams(window.location.search);
@@ -22,5 +23,5 @@
 <div class="container">
   <UsernameDisplay username={toId} />
   <AmountPicker onSelect={val => amount = val} />
-  <button class="btn" on:click={confirm}>Подарить</button>
+  <RippleButton onClick={confirm}>Подарить</RippleButton>
 </div>

--- a/frontend/src/pages/History.svelte
+++ b/frontend/src/pages/History.svelte
@@ -1,5 +1,6 @@
 <script>
   import { onMount } from 'svelte'
+  import HistoryCard from '../components/HistoryCard.svelte'
 
   let records = []
 
@@ -9,14 +10,14 @@
 </script>
 
 <div class="container">
-  <h2>/history</h2>
+  <h2 class="fancy-text">История</h2>
   {#if records.length === 0}
     <p>Вы сами пишете свою историю</p>
   {:else}
-    <ul>
+    <div>
       {#each records as r}
-        <li>{new Date(r.time).toLocaleDateString()} - {r.amount} ⭐ - ${r.fiat.toFixed(2)}</li>
+        <HistoryCard record={r} />
       {/each}
-    </ul>
+    </div>
   {/if}
 </div>

--- a/frontend/src/pages/Success.svelte
+++ b/frontend/src/pages/Success.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { navigate } from '../router.js';
+  import RippleButton from '../components/RippleButton.svelte';
   let purchase = null;
 
   onMount(() => {
@@ -14,7 +15,7 @@
     <p>Вы купили {purchase.amount} ⭐ за ${purchase.fiat.toFixed(2)}</p>
     <p class="time">{new Date(purchase.time).toLocaleString()}</p>
   {/if}
-  <button class="btn" on:click={() => navigate('/')}>На главную</button>
+  <RippleButton onClick={() => navigate('/')}>На главную</RippleButton>
 </div>
 
 <style>

--- a/frontend/src/pages/Welcome.svelte
+++ b/frontend/src/pages/Welcome.svelte
@@ -1,13 +1,14 @@
 <script>
   import { navigate } from "../router.js";
   import History from "./History.svelte";
+  import RippleButton from "../components/RippleButton.svelte";
 </script>
 
 <div class="container">
-  <h1 class="header">Star ⭐ Pay Terminal</h1>
+  <h1 class="header fancy-text">Star ⭐ Pay Terminal</h1>
   <div class="button-group">
-    <button class="btn" on:click={() => navigate("/buy")}>🌟 Купить звёзды</button>
-    <button class="btn" on:click={() => navigate("/buy")}>🎁 Подарить звёзды</button>
+    <RippleButton onClick={() => navigate("/buy")}>🌟 Купить звёзды</RippleButton>
+    <RippleButton onClick={() => navigate("/buy")}>🎁 Подарить звёзды</RippleButton>
   </div>
   <History></History>
 </div>


### PR DESCRIPTION
## Summary
- style headers with gradient text
- add RippleButton component and use it across pages
- display history records in collapsible cards

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867d56bb3a48322856ff47c68058a20