### PR TITLE
Configure button colors

### DIFF
--- a/frontend/src/components/HistoryCard.svelte
+++ b/frontend/src/components/HistoryCard.svelte
@@ -21,8 +21,8 @@
 
 <style>
   .card {
-    background: #fff;
-    color: #000;
+    background: var(--tg-secondary-bg-color, #fff);
+    color: var(--tg-text-color, #000);
     border-radius: 8px;
     padding: 12px;
     margin-bottom: 10px;
@@ -37,6 +37,6 @@
   .details {
     margin-top: 8px;
     font-size: 14px;
-    color: #555;
+    color: var(--tg-hint-color, #555);
   }
 </style>

--- a/frontend/src/components/RippleButton.svelte
+++ b/frontend/src/components/RippleButton.svelte
@@ -38,8 +38,8 @@
     justify-content: center;
     padding: 16px;
     width: 100%;
-    background: #fff;
-    color: #000;
+    background: var(--tg-button-color, #0077ff);
+    color: var(--tg-button-text-color, #fff);
     border-radius: 8px;
     font-size: 16px;
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -60,7 +60,7 @@ body {
   padding: 10px 15px;
   background: var(--tg-secondary-bg-color, #fff);
   border: 1px solid var(--tg-hint-color, #ccc);
-  color: #333;
+  color: var(--tg-text-color, #333);
   border-radius: 4px;
   cursor: pointer;
 }
@@ -90,7 +90,7 @@ input::-webkit-inner-spin-button {
 button {
   border: none;
   padding: 0.5rem 2rem;
-  color: #fff;
+  color: var(--tg-button-text-color, #fff);
   font-size: 1.5rem;
   border-radius: 1rem;
   transition: all 250ms;


### PR DESCRIPTION
## Summary
- apply Telegram theme variables to RippleButton and HistoryCard
- use theme colors for generic buttons and amounts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68693e45258883229811eca4be137fc7