### PR TITLE
feature/telegram-recipient-search

### DIFF
--- a/frontend/src/components/UserSearch.svelte
+++ b/frontend/src/components/UserSearch.svelte
@@ -1,0 +1,30 @@
+<script>
+  let query = ''
+  function search() {
+    const tg = window.Telegram.WebApp
+    if (tg?.switchInlineQuery) {
+      tg.switchInlineQuery(query)
+    }
+  }
+</script>
+
+  <div class="search-box">
+    <input
+      placeholder="Поиск получателя"
+      bind:value={query}
+      on:keydown={(e) => e.key === 'Enter' && search()}
+    />
+    <button on:click={search}>Найти в Telegram</button>
+  </div>
+
+<style>
+  .search-box input {
+    width: 100%;
+    padding: 8px;
+    margin: 10px 0;
+    border-radius: 4px;
+    border: 1px solid #265e2f;
+    background: var(--tg-secondary-bg-color, #0f172a);
+    color: var(--tg-text-color, #fff);
+  }
+</style>

--- a/frontend/src/pages/Gift.svelte
+++ b/frontend/src/pages/Gift.svelte
@@ -4,11 +4,13 @@
   import { navigate } from '../router.js';
   import { gift } from '../api.js';
   import RippleButton from '../components/RippleButton.svelte';
+  import UserSearch from '../components/UserSearch.svelte';
 
   let amount = 0;
   const params = new URLSearchParams(window.location.search);
-  const toId = params.get('user_id');
-  const username = params.get('username') || toId;
+  let toId = params.get('user_id');
+  let username = params.get('username') || '';
+
 
   function confirm() {
     const fromId = window.Telegram.WebApp.initDataUnsafe?.user?.id;
@@ -34,7 +36,10 @@
 
 <div class="container">
   <RippleButton onClick={() => navigate("/")}>←</RippleButton>
-  <UsernameDisplay username={username} />
+  <UserSearch />
+  {#if toId}
+    <UsernameDisplay username={username || toId} />
+  {/if}
   <AmountPicker onSelect={val => amount = val} />
   <RippleButton kind="gift" onClick={confirm}>Подарить</RippleButton>
 </div>


### PR DESCRIPTION
## Summary
- open Telegram inline query from `Gift` page
- remove local user mock
- call `switchInlineQuery` for search

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run deploy --silent` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a6e5292c83229ae84cd5e4538233