### PR TITLE
Implement Telegram user search

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -1,11 +1,17 @@
 const TelegramBot = require('node-telegram-bot-api');
 const menuHandler = require('./handlers/menuHandler');
 const inlineQueryHandler = require('./handlers/inlineQueryHandler');
+const app = require('./server');
 
 const token = process.env.BOT_TOKEN;
 const bot = new TelegramBot(token, { polling: true });
 
 bot.onText(/\/start/, (msg) => menuHandler(bot, msg));
 bot.on('inline_query', (query) => inlineQueryHandler(bot, query));
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => console.log(`Server running on ${port}`));
+}
 
 module.exports = bot;

--- a/bot/searchUser.js
+++ b/bot/searchUser.js
@@ -1,0 +1,16 @@
+
+const TelegramBot = require('node-telegram-bot-api');
+
+module.exports = async function searchUser(username) {
+  if (!username) return null;
+  const token = process.env.BOT_TOKEN;
+  if (!token) throw new Error('BOT_TOKEN missing');
+  const bot = new TelegramBot(token);
+  const query = username.startsWith('@') ? username : `@${username}`;
+  try {
+    const chat = await bot.getChat(query);
+    return { id: chat.id, username: chat.username || chat.title || username };
+  } catch {
+    return null;
+  }
+};

--- a/bot/server.js
+++ b/bot/server.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const searchUser = require('./searchUser');
+
+const app = express();
+
+app.get('/search', async (req, res) => {
+  const { q } = req.query;
+  const result = await searchUser(q);
+  if (result) {
+    res.json({ ok: true, result });
+  } else {
+    res.status(404).json({ ok: false });
+  }
+});
+
+module.exports = app;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -20,3 +20,10 @@ export async function getHistory(user_id) {
   const res = await fetch(`/history?user_id=${user_id}`);
   return res.json();
 }
+
+export async function searchUser(query) {
+  const res = await fetch(`/search?q=${encodeURIComponent(query)}`);
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.ok ? data.result : null;
+}

--- a/frontend/src/components/UserSearch.svelte
+++ b/frontend/src/components/UserSearch.svelte
@@ -1,9 +1,15 @@
 <script>
+  import { searchUser } from '../api.js'
   let query = ''
-  function search() {
-    const tg = window.Telegram.WebApp
-    if (tg?.switchInlineQuery) {
-      tg.switchInlineQuery(query)
+  async function search() {
+    const result = await searchUser(query)
+    if (result) {
+      const params = new URLSearchParams(window.location.search)
+      params.set('user_id', result.id)
+      params.set('username', result.username)
+      window.location.search = params.toString()
+    } else {
+      alert('Пользователь не найден')
     }
   }
 </script>

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",
     "node-telegram-bot-api": "^0.66.0",
-    "tailwindcss": "^4.1.11"
+    "tailwindcss": "^4.1.11",
+    "express": "^4.19.2"
   },
   "devDependencies": {
     "jest": "^30.0.3",
-    "supertest": "^7.1.1"
+    "supertest": "^7.1.1",
+    "nock": "^13.4.0"
   },
   "jest": {
     "testEnvironment": "node"

--- a/test/searchUser.test.js
+++ b/test/searchUser.test.js
@@ -1,0 +1,34 @@
+const nock = require('nock');
+const app = require('../bot/server');
+const request = require('supertest');
+const searchUser = require('../bot/searchUser');
+
+describe('Telegram user search', () => {
+  afterEach(() => nock.cleanAll());
+  beforeAll(() => {
+    nock.disableNetConnect();
+    nock.enableNetConnect('127.0.0.1');
+  });
+
+  test('finds user by username', async () => {
+    process.env.BOT_TOKEN = 'TOKEN';
+    nock('https://api.telegram.org')
+      .post('/botTOKEN/getChat', { chat_id: '@alice' })
+      .reply(200, { ok: true, result: { id: 1, username: 'alice' } });
+
+    const res = await request(app).get('/search').query({ q: 'alice' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, result: { id: 1, username: 'alice' } });
+  });
+
+  test('returns 404 for unknown user', async () => {
+    process.env.BOT_TOKEN = 'TOKEN';
+    nock('https://api.telegram.org')
+      .post('/botTOKEN/getChat', { chat_id: '@unknown' })
+      .reply(404);
+
+    const res = await request(app).get('/search').query({ q: 'unknown' });
+    expect(res.status).toBe(404);
+    expect(res.body.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add API to query Telegram for user information
- start express server in the bot for `/search`
- use the new search API from UserSearch component
- add tests for Telegram search

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686a05569d0c832295db721184bcf602