### PR TITLE
Change bot menu to inline buttons

### DIFF
--- a/bot/handlers/menuHandler.js
+++ b/bot/handlers/menuHandler.js
@@ -1,12 +1,20 @@
 module.exports = function menuHandler(bot, msg) {
-  bot.sendMessage(msg.chat.id, 'Привет! Что хочешь сделать?.', {
+  bot.sendMessage(msg.chat.id, 'Привет! Что хочешь сделать?', {
     reply_markup: {
-      keyboard: [
-        [{ text: '🌟 Купить звёзды' },
-        { text: '🎁 Подарить звёзды другу', request_user: { request_id: 1, user_is_bot: false } }]
-      ],
-      resize_keyboard: true,
-      one_time_keyboard: true
+      inline_keyboard: [
+        [
+          {
+            text: '🌟 Купить звёзды',
+            web_app: { url: 'https://skyfet.github.io/cryptonewton/#/buy' }
+          }
+        ],
+        [
+          {
+            text: '🎁 Подарить звёзды другу',
+            web_app: { url: 'https://skyfet.github.io/cryptonewton/?mode=gift' }
+          }
+        ]
+      ]
     }
   });
 };


### PR DESCRIPTION
## Summary
- use inline buttons for the start menu

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686c4f760430832285cd068002ea1684